### PR TITLE
[ci] fix deploy

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -48,10 +48,6 @@ jobs:
         uses: actions/configure-pages@v5
       - name: Install Node.js dependencies
         run: "[[ -f docs/package-lock.json || -f docs/npm-shrinkwrap.json ]] && cd docs && npm ci || true"
-      - name: Generate Rust documentation
-        run: |
-          cargo doc --no-deps
-          mv target/doc docs/public/rust
       - name: Build with Hugo
         env:
           # For maximum backward compatibility with Hugo modules
@@ -62,6 +58,10 @@ jobs:
           hugo \
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
+      - name: Generate Rust documentation
+        run: |
+          cargo doc --no-deps
+          mv target/doc docs/public/rust
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
No `docs/public` directory existed for the `mv` command after `cargo doc`