### PR TITLE
updated deps

### DIFF
--- a/.github/workflows/rust-unix.yml
+++ b/.github/workflows/rust-unix.yml
@@ -1,0 +1,33 @@
+name: Rust Build/Test
+on:
+  push:
+    branches-ignore:
+      - "main"
+    paths:
+      - "tests/**/*.rs"
+      - "src/**/*.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  pull_request:
+    branches:
+      - "main"
+    paths:
+      - "tests/**/*.rs"
+      - "src/**/*.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  call-build:
+    strategy:
+      matrix:
+        runner: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Call build workflow
+        uses: ./.github/workflows/rust.yml
+        with:
+          runner: ${{ matrix.runner }}

--- a/.github/workflows/rust-unix.yml
+++ b/.github/workflows/rust-unix.yml
@@ -28,8 +28,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: "${{ github.head_ref || github.ref }}"
       - name: Call build workflow
         uses: ./.github/workflows/rust.yml
         with:

--- a/.github/workflows/rust-unix.yml
+++ b/.github/workflows/rust-unix.yml
@@ -29,6 +29,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Call build workflow
-        uses: ./.github/workflows/rust.yml
+        uses: ./.github/workflows/rust.yml@deps
         with:
           runner: ${{ matrix.runner }}

--- a/.github/workflows/rust-unix.yml
+++ b/.github/workflows/rust-unix.yml
@@ -25,10 +25,6 @@ jobs:
     strategy:
       matrix:
         runner: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Call build workflow
-        uses: ./.github/workflows/rust.yml@deps
-        with:
-          runner: ${{ matrix.runner }}
+    uses: ./.github/workflows/rust.yml
+    with:
+      runner: ${{ matrix.runner }}

--- a/.github/workflows/rust-unix.yml
+++ b/.github/workflows/rust-unix.yml
@@ -27,6 +27,7 @@ jobs:
         runner: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.runner }}
     steps:
+      - uses: actions/checkout@v4
       - name: Call build workflow
         uses: ./.github/workflows/rust.yml
         with:

--- a/.github/workflows/rust-unix.yml
+++ b/.github/workflows/rust-unix.yml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: "${{ github.head_ref || github.ref }}"
       - name: Call build workflow
         uses: ./.github/workflows/rust.yml
         with:

--- a/.github/workflows/rust-windows.yml
+++ b/.github/workflows/rust-windows.yml
@@ -14,8 +14,6 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: "${{ github.head_ref || github.ref }}"
       - name: Call build workflow
         uses: ./.github/workflows/rust.yml
         with:

--- a/.github/workflows/rust-windows.yml
+++ b/.github/workflows/rust-windows.yml
@@ -11,10 +11,6 @@ env:
 
 jobs:
   call-build:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Call build workflow
-        uses: ./.github/workflows/rust.yml@deps
-        with:
-          runner: windows-latest
+    uses: ./.github/workflows/rust.yml
+    with:
+      runner: windows-latest

--- a/.github/workflows/rust-windows.yml
+++ b/.github/workflows/rust-windows.yml
@@ -1,0 +1,19 @@
+name: Rust Build/Test on Windows
+
+# This workflow is triggered manually.  Testing on
+# Windows is not as important as testing on Unix, and it takes
+# a lot longer to run.
+on:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  call-build:
+    runs-on: windows-latest
+    steps:
+      - name: Call build workflow
+        uses: ./.github/workflows/rust.yml
+        with:
+          runner: windows-latest

--- a/.github/workflows/rust-windows.yml
+++ b/.github/workflows/rust-windows.yml
@@ -15,6 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Call build workflow
-        uses: ./.github/workflows/rust.yml
+        uses: ./.github/workflows/rust.yml@deps
         with:
           runner: windows-latest

--- a/.github/workflows/rust-windows.yml
+++ b/.github/workflows/rust-windows.yml
@@ -13,6 +13,7 @@ jobs:
   call-build:
     runs-on: windows-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Call build workflow
         uses: ./.github/workflows/rust.yml
         with:

--- a/.github/workflows/rust-windows.yml
+++ b/.github/workflows/rust-windows.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: "${{ github.head_ref || github.ref }}"
       - name: Call build workflow
         uses: ./.github/workflows/rust.yml
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,6 @@ jobs:
   build:
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@v4
       - name: Print Cargo.lock hash
         run: "echo 'Cargo.lock hash: ' ${{ hashFiles('**/Cargo.lock') }}"
       - uses: actions/cache@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     runs-on: ${{ inputs.runner }}
     steps:
+      - uses: actions/checkout@v4
       - name: Print Cargo.lock hash
         run: "echo 'Cargo.lock hash: ' ${{ hashFiles('**/Cargo.lock') }}"
       - uses: actions/cache@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,31 +1,16 @@
-name: Rust Build/Test
+name: Rust Build/Test Base
 
 on:
-  push:
-    branches-ignore:
-      - "main"
-    paths:
-      - "tests/**/*.rs"
-      - "src/**/*.rs"
-      - "Cargo.toml"
-      - "Cargo.lock"
-  pull_request:
-    branches:
-      - "main"
-    paths:
-      - "tests/**/*.rs"
-      - "src/**/*.rs"
-      - "Cargo.toml"
-      - "Cargo.lock"
-env:
-  CARGO_TERM_COLOR: always
+  workflow_call:
+    inputs:
+      runner:
+        description: "The runner to use"
+        required: true
+        type: string
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v4
       - name: Print Cargo.lock hash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
+name = "bstr"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "noodles-bgzf"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff82b0fb78c11947b29ef50e8ddf0093813fa9e613af0e13dc53fc12b2dc3ea"
+checksum = "13f54d4840fd26ed94103ded9524aa5fdd757255a556f24653d162c0a45c47e8"
 dependencies = [
  "byteorder",
  "bytes",
@@ -204,15 +214,18 @@ dependencies = [
 
 [[package]]
 name = "noodles-core"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7336c3be652de4e05444c9b12a32331beb5ba3316e8872d92bfdd8ef3b06c282"
+checksum = "c5a8c6b020d1205abef2b0fab4463a6c5ecc3c8f4d561ca8b0d1a42323376200"
+dependencies = [
+ "bstr",
+]
 
 [[package]]
 name = "noodles-fasta"
-version = "0.35.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f7006eff28b06d2c2b1129f9dd2ba637163b92068617060433f22f557e6ce2"
+checksum = "8bf9160022ada6c905f4e54aa27dd1ebde8d48faf6fb4dcd0f3ec423adc241ec"
 dependencies = [
  "bytes",
  "memchr",
@@ -245,6 +258,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.202"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.202"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dependencies]
 approx = "0.5.1"
 clap = { version = "4.5.4", features = ["derive"] }
-noodles-core = "0.14.0"
-noodles-fasta = "0.35.0"
+noodles-core = "0.15.0"
+noodles-fasta = "0.38.0"


### PR DESCRIPTION
- noodles-core to 0.15.0
- noodles-fasta to 0.38.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new GitHub Actions workflows for building and testing Rust code on Unix (`rust-unix.yml`) and Windows (`rust-windows.yml`) environments.

- **Chores**
  - Updated the existing Rust build/test workflow to use a more flexible configuration with `workflow_call` and input parameters for runners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->