### PR TITLE
[docs] DataTables needs jQuery

### DIFF
--- a/docs/content/docs/guides/example.md
+++ b/docs/content/docs/guides/example.md
@@ -18,7 +18,8 @@ seo:
   noindex: false # false (default) or true
 ---
 <link rel="stylesheet" href="https://cdn.datatables.net/2.0.7/css/dataTables.dataTables.css" />
-  
+<!-- (jQuery needed for DataTables) -->
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
 <script src="https://cdn.datatables.net/2.0.7/js/dataTables.js"></script>
 
 ### Sequence


### PR DESCRIPTION
jQuery was removed from custom-footer but is still needed on the page with example tables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the example guide to include a script tag for jQuery, enhancing DataTables functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->